### PR TITLE
Upgrade aws-cdk-lib to 2.91.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aws-cdk-lib==2.12.0
+aws-cdk-lib==2.91.0
 constructs>=10.0.0,<11.0.0
 pyyaml==6.0
 pytest==7.0.1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update version of aws-cdk-lib to 2.91.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
